### PR TITLE
fix ini generation for campus

### DIFF
--- a/python/smap/drivers/obvius/auth.py
+++ b/python/smap/drivers/obvius/auth.py
@@ -1,0 +1,4 @@
+BMOROOT = 'http://www.buildingmanageronline.com/members/'
+STATUSPAGE = 'client_status.php?DB=dbU216ucberkelF682'
+AUTH = ('ucbguest', 'ucbguest')
+BMOAUTH = AUTH

--- a/python/smap/drivers/obvius/crawl_bmo.py
+++ b/python/smap/drivers/obvius/crawl_bmo.py
@@ -215,7 +215,7 @@ elif opts.load:
             cf.add_section(meter_path)
             cf.set(meter_path, 'type', 'smap.drivers.obvius.bmo.BMOLoader')
             cf.set(meter_path, 'Metadata/Extra/MeterName', metername)
-            cf.set(meter_path, 'Metadata/Instrument/Model', metertype)
+            cf.set(meter_path, 'Metadata/Instrument/Model', '"' + metertype + '"')
             cf.set(meter_path, 'Metadata/Location/Building', building_name)
             cf.set(meter_path, 'Url', url)
 


### PR DESCRIPTION
This should fix generating the ini for the campus BMO driver. I've also committed `auth.py` since the credentials were already present in `crawl_bmo.py`.
